### PR TITLE
Improve DOCX placeholder handling and robustly replace text runs

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ import zipfile
 import shutil
 import subprocess
 import xml.etree.ElementTree as ET
+from decimal import Decimal
+from lxml import etree as LET
+from jinja2 import Environment, DebugUndefined
 from typing import Dict, Tuple, List, Optional
 
 from fastapi import FastAPI, UploadFile, File, Form
@@ -40,6 +43,9 @@ def err(m, status=400): return JSONResponse(status_code=status, content={"error"
 VAR_NAME = r"[A-Za-z_][A-Za-z0-9_]*"
 IMG_KEY_PATTERN = re.compile(rf"^\{{\[(?P<var>{VAR_NAME})\](?::(?P<size>[^}}]+))?\}}$")
 TXT_KEY_PATTERN = re.compile(rf"^\{{(?P<var>{VAR_NAME})\}}$")
+IMG_TAG_PATTERN = re.compile(rf"\{{\[(?P<var>{VAR_NAME})\](?::(?P<size>[^}}]+))?\}}")
+IMG_TAG_INLINE = re.compile(rf"(?<!\{{)\{{\[\s*(?P<var>{VAR_NAME})\s*\](?::(?P<size>[^}}]+))?\}}(?!\}})")
+TXT_TAG_INLINE = re.compile(rf"(?<!\{{)\{{\s*(?P<var>{VAR_NAME})\s*\}}(?!\}})")
 MM_RE      = re.compile(r'^\s*(\d+(?:\.\d+)?)\s*mm\s*$', re.IGNORECASE)
 NUM_PLAIN  = re.compile(r'^\s*-?\d+(?:\.\d+)?\s*$')
 NUM_COMMA  = re.compile(r'^\s*-?\d{1,3}(?:,\d{3})+(?:\.\d+)?\s*$')
@@ -48,6 +54,12 @@ NUM_PCT    = re.compile(r'^\s*-?\d+(?:\.\d+)?\s*%\s*$')
 def parse_size_mm(s: Optional[str]) -> Optional[float]:
     if not s: return None
     m = MM_RE.match(s.strip()); return float(m.group(1)) if m else None
+
+def parse_image_tag(text: Optional[str]) -> Tuple[Optional[str], Optional[float]]:
+    if not text: return None, None
+    m = IMG_TAG_PATTERN.fullmatch(text.strip())
+    if not m: return None, None
+    return m.group("var"), parse_size_mm(m.group("size") or "")
 
 def parse_numberlike(s: str) -> Tuple[Optional[float], Optional[str]]:
     if s is None: return None, None
@@ -65,6 +77,20 @@ def parse_numberlike(s: str) -> Tuple[Optional[float], Optional[str]]:
             return (float(c), None) if "." in c else (int(c), None)
         except: return None, None
     return None, None
+
+def _format_formula_value(value) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        if value == value.to_integral():
+            value = int(value)
+        else:
+            value = float(value)
+    if isinstance(value, bool):
+        return "1" if value else "0"
+    if isinstance(value, (int, float)):
+        return str(value)
+    return str(value)
 
 def _with_newlines(v: str) -> str:
     return (v or "").replace("<br>", "\n")
@@ -90,9 +116,13 @@ def parse_mapping_text(raw: str) -> Tuple[Dict[str, str], Dict[str, Dict]]:
             if seg: items.append(seg.replace(SAFE, "://"))
 
     for seg in items:
-        if ":" not in seg: continue
-        key, value = seg.split(":", 1)
-        key = key.strip(); value = value.strip()
+        if "}" not in seg:
+            continue
+        close = seg.find("}")
+        key = seg[:close+1].strip()
+        value = seg[close+1:].lstrip(":").strip()
+        if not key:
+            continue
 
         m_img = IMG_KEY_PATTERN.match(key)
         if m_img:
@@ -129,6 +159,127 @@ def parse_pages_arg(pages: str, total_pages: int) -> List[int]:
 
 # ------------ Word (.docx) ------------
 WORD_XML_TARGETS = ("word/document.xml","word/footnotes.xml","word/endnotes.xml","word/comments.xml")
+W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+S_NS = "http://schemas.openxmlformats.org/spreadsheetml/2006/main"
+R_NS = "http://schemas.openxmlformats.org/officeDocument/2006/relationships"
+XML_NS = "http://www.w3.org/XML/1998/namespace"
+
+def _word_collect_text_nodes(root) -> List[Tuple[LET._Element, int, int]]:
+    nodes: List[Tuple[LET._Element, int, int]] = []
+    cursor = 0
+    for t in root.iter(f"{{{W_NS}}}t"):
+        text = t.text or ""
+        start = cursor
+        cursor += len(text)
+        nodes.append((t, start, cursor))
+    return nodes
+
+def _word_replace_range(root, start: int, end: int, replacement: str):
+    nodes = _word_collect_text_nodes(root)
+    inserted = False
+    for node, node_start, node_end in nodes:
+        if node_end <= start or node_start >= end:
+            continue
+        text = node.text or ""
+        local_start = max(0, start - node_start)
+        local_end = min(len(text), end - node_start)
+        before = text[:local_start]
+        after = text[local_end:]
+        if not inserted:
+            node.text = before + replacement + after
+            inserted = True
+        else:
+            node.text = before + after
+
+def _word_set_text(node: LET._Element, text: str):
+    run = node.getparent()
+    if run is None or run.tag != f"{{{W_NS}}}r":
+        node.text = text
+        return
+
+    children = list(run)
+    try:
+        idx = children.index(node)
+    except ValueError:
+        idx = -1
+
+    # remove text/break nodes after the current text node so we can rebuild
+    if idx >= 0:
+        for child in children[idx + 1:]:
+            if child.tag in {f"{{{W_NS}}}t", f"{{{W_NS}}}br"}:
+                run.remove(child)
+
+    parts = text.split("\n")
+    first = parts[0] if parts else ""
+    node.text = first
+    if first.strip() != first or "\n" in first or first == "":
+        node.set(f"{{{XML_NS}}}space", "preserve")
+    else:
+        node.attrib.pop(f"{{{XML_NS}}}space", None)
+
+    for part in parts[1:]:
+        br = LET.Element(f"{{{W_NS}}}br")
+        run.append(br)
+        t = LET.Element(f"{{{W_NS}}}t")
+        t.set(f"{{{XML_NS}}}space", "preserve")
+        t.text = part
+        run.append(t)
+
+def _word_replace_range_with_text(root, start: int, end: int, replacement: str):
+    nodes = _word_collect_text_nodes(root)
+    inserted = False
+    for node, node_start, node_end in nodes:
+        if node_end <= start or node_start >= end:
+            continue
+        text = node.text or ""
+        local_start = max(0, start - node_start)
+        local_end = min(len(text), end - node_start)
+        before = text[:local_start]
+        after = text[local_end:]
+        combined = before + replacement + after
+        if not inserted:
+            _word_set_text(node, combined)
+            inserted = True
+        else:
+            _word_set_text(node, before + after)
+
+def _word_convert_placeholders(root, size_hints: Dict[str, Optional[float]]):
+    while True:
+        nodes = _word_collect_text_nodes(root)
+        if not nodes:
+            break
+        full_text = "".join((node.text or "") for node, _, _ in nodes)
+        m_img = IMG_TAG_INLINE.search(full_text)
+        if m_img:
+            var = m_img.group("var")
+            size = parse_size_mm(m_img.group("size") or "")
+            if size is not None:
+                size_hints.setdefault(var, size)
+            _word_replace_range(root, m_img.start(), m_img.end(), f"{{{{ {var} }}}}")
+            continue
+        m_txt = TXT_TAG_INLINE.search(full_text)
+        if m_txt:
+            var = m_txt.group("var")
+            _word_replace_range(root, m_txt.start(), m_txt.end(), f"{{{{ {var} }}}}")
+            continue
+        break
+
+WORD_JINJA_PATTERN = re.compile(r"\{\{\s*(?P<var>%s)\s*\}\}" % VAR_NAME)
+
+def _word_apply_text_map(root, text_map: Dict[str, str]):
+    if not text_map:
+        return
+    while True:
+        nodes = _word_collect_text_nodes(root)
+        if not nodes:
+            break
+        full_text = "".join((node.text or "") for node, _, _ in nodes)
+        m = WORD_JINJA_PATTERN.search(full_text)
+        if not m:
+            break
+        var = m.group("var")
+        replacement = text_map.get(var, "")
+        _word_replace_range_with_text(root, m.start(), m.end(), replacement)
 
 def _word_content_xmls(extracted_dir: str) -> List[str]:
     targets = list(WORD_XML_TARGETS)
@@ -139,17 +290,19 @@ def _word_content_xmls(extracted_dir: str) -> List[str]:
             if fn.startswith("footer") and fn.endswith(".xml"): targets.append(f"word/{fn}")
     return [os.path.join(extracted_dir, p) for p in targets if os.path.exists(os.path.join(extracted_dir, p))]
 
-def docx_convert_tags_to_jinja(in_docx: str, out_docx: str):
+def docx_convert_tags_to_jinja(in_docx: str, out_docx: str) -> Dict[str, Optional[float]]:
     # {var}/{[var]} → {{ var }} へ。英数字+下線のタグのみ変換（Jinja誤爆防止）
     tmpdir = tempfile.mkdtemp()
+    size_hints: Dict[str, Optional[float]] = {}
     try:
         with zipfile.ZipFile(in_docx, 'r') as zin:
             zin.extractall(tmpdir)
         for p in _word_content_xmls(tmpdir):
-            s = open(p, "r", encoding="utf-8").read()
-            s = re.sub(rf"\{{\[\s*({VAR_NAME})\s*\]\}}", r"{{ \1 }}", s)
-            s = re.sub(rf"\{{\s*({VAR_NAME})\s*\}}",       r"{{ \1 }}", s)
-            open(p, "w", encoding="utf-8").write(s)
+            parser = LET.XMLParser(remove_blank_text=False)
+            tree = LET.parse(p, parser)
+            root = tree.getroot()
+            _word_convert_placeholders(root, size_hints)
+            tree.write(p, encoding="utf-8", xml_declaration=True)
         with zipfile.ZipFile(out_docx, 'w', zipfile.ZIP_DEFLATED) as zout:
             for root, _, files in os.walk(tmpdir):
                 for fn in files:
@@ -157,6 +310,7 @@ def docx_convert_tags_to_jinja(in_docx: str, out_docx: str):
                     zout.write(full, os.path.relpath(full, tmpdir))
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
+    return size_hints
 
 def docx_render(in_docx: str, out_docx: str, text_map: Dict[str, str], image_map: Dict[str, Dict]):
     from docxtpl import DocxTemplate, InlineImage
@@ -164,16 +318,19 @@ def docx_render(in_docx: str, out_docx: str, text_map: Dict[str, str], image_map
     import requests
 
     tmp = in_docx + ".jinja.docx"
-    docx_convert_tags_to_jinja(in_docx, tmp)
+    size_hints = docx_convert_tags_to_jinja(in_docx, tmp)
 
     doc = DocxTemplate(tmp)
     ctx: Dict[str, object] = {}
-    for k, v in text_map.items(): ctx[k] = v
+    for k, v in text_map.items():
+        ctx[k] = v
     for k, meta in image_map.items():
         r = requests.get(meta["url"], timeout=20); r.raise_for_status()
         bio = io.BytesIO(r.content)
-        ctx[k] = InlineImage(doc, bio, width=Mm(meta["mm"])) if meta.get("mm") else InlineImage(doc, bio)
-    doc.render(ctx)
+        mm = meta.get("mm") or size_hints.get(k)
+        ctx[k] = InlineImage(doc, bio, width=Mm(mm)) if mm else InlineImage(doc, bio)
+    jinja_env = Environment(autoescape=False, undefined=DebugUndefined)
+    doc.render(ctx, jinja_env=jinja_env)
     doc.save(out_docx)
     os.remove(tmp)
 
@@ -183,10 +340,11 @@ def docx_render(in_docx: str, out_docx: str, text_map: Dict[str, str], image_map
         with zipfile.ZipFile(out_docx, 'r') as zin:
             zin.extractall(tmpdir)
         for p in _word_content_xmls(tmpdir):
-            s = open(p, "r", encoding="utf-8").read()
-            for k, v in text_map.items():
-                s = s.replace(f"{{{{ {k} }}}}", v).replace(f"{{{{{k}}}}}", v)
-            open(p, "w", encoding="utf-8").write(s)
+            parser = LET.XMLParser(remove_blank_text=False)
+            tree = LET.parse(p, parser)
+            root = tree.getroot()
+            _word_apply_text_map(root, text_map)
+            tree.write(p, encoding="utf-8", xml_declaration=True)
         with zipfile.ZipFile(out_docx, 'w', zipfile.ZIP_DEFLATED) as zout:
             for root, _, files in os.walk(tmpdir):
                 for fn in files:
@@ -196,19 +354,156 @@ def docx_render(in_docx: str, out_docx: str, text_map: Dict[str, str], image_map
         shutil.rmtree(tmpdir, ignore_errors=True)
 
 # ------------ Excel (.xlsx) ------------
+def _xlsx_sheet_map(extracted_dir: str) -> Dict[str, Tuple[Optional[str], Optional[int]]]:
+    mapping: Dict[str, Tuple[Optional[str], Optional[int]]] = {}
+    workbook_xml = os.path.join(extracted_dir, "xl", "workbook.xml")
+    rels_xml = os.path.join(extracted_dir, "xl", "_rels", "workbook.xml.rels")
+    if not os.path.exists(workbook_xml):
+        return mapping
+
+    rid_to_target: Dict[str, str] = {}
+    if os.path.exists(rels_xml):
+        tree = ET.parse(rels_xml); root = tree.getroot()
+        for rel in root.findall(f".//{{{R_NS}}}Relationship"):
+            if rel.get("Type", "").endswith("/worksheet"):
+                rid = rel.get("Id"); target = rel.get("Target")
+                if rid and target:
+                    rid_to_target[rid] = target.replace('\\', '/')
+
+    ns = {"s": S_NS, "r": R_NS}
+    tree = ET.parse(workbook_xml); root = tree.getroot()
+    sheets = root.find("s:sheets", ns)
+    if sheets is None:
+        return mapping
+    for idx, sheet in enumerate(sheets.findall("s:sheet", ns)):
+        name = sheet.get("name")
+        rid = sheet.get(f"{{{R_NS}}}id")
+        target = rid_to_target.get(rid or "")
+        if target:
+            rel_path = os.path.normpath(os.path.join("xl", target))
+            basename = os.path.basename(rel_path)
+            mapping[basename] = (name, idx)
+    return mapping
+
 def xlsx_force_full_recalc(extracted_dir: str):
     p = os.path.join(extracted_dir, "xl", "workbook.xml")
     if not os.path.exists(p): return
-    ns = {"s":"http://schemas.openxmlformats.org/spreadsheetml/2006/main"}
+    ns = {"s": S_NS}
     tree = ET.parse(p); root = tree.getroot()
     calcPr = root.find("s:calcPr", ns) or ET.SubElement(root, f"{{{ns['s']}}}calcPr")
     calcPr.set("calcMode", "auto")
     calcPr.set("fullCalcOnLoad", "1")
+    calcPr.set("calcOnSave", "1")
+    calcPr.set("forceFullCalc", "1")
     chain = os.path.join(extracted_dir, "xl", "calcChain.xml")
     if os.path.exists(chain):
         try: os.remove(chain)
         except: pass
     tree.write(p, encoding="utf-8", xml_declaration=True)
+
+def _xlsx_escape_sheet_name(name: str) -> str:
+    if not name:
+        return ""
+    if re.search(r"[\s'!]", name):
+        return "'" + name.replace("'", "''") + "'"
+    return name
+
+def xlsx_update_formula_caches(xlsx_path: str, formula_cells: List[Dict]):
+    if not formula_cells:
+        return
+    try:
+        from xlcalculator import ModelCompiler, Evaluator
+    except Exception:
+        return
+
+    try:
+        compiler = ModelCompiler()
+        model = compiler.read_and_parse_archive(xlsx_path)
+        evaluator = Evaluator(model)
+    except Exception:
+        return
+
+    computed: Dict[Tuple[str, str], Optional[str]] = {}
+    sheet_names_by_index: List[str] = []
+    try:
+        # model.cells keys look like "Sheet!A1"; derive sheet list lazily
+        seen = []
+        for key in model.cells.keys():
+            sheet_part = key.split("!", 1)[0]
+            if sheet_part not in seen:
+                seen.append(sheet_part)
+        sheet_names_by_index = seen
+    except Exception:
+        sheet_names_by_index = []
+
+    for info in formula_cells:
+        cell_ref = info.get("cell_ref")
+        sheet_file = info.get("sheet_file")
+        sheet_name = info.get("sheet_name")
+        sheet_index = info.get("sheet_index")
+        if not cell_ref or not sheet_file:
+            continue
+        if not sheet_name and sheet_index is not None and 0 <= sheet_index < len(sheet_names_by_index):
+            sheet_name = sheet_names_by_index[sheet_index]
+        if not sheet_name:
+            continue
+        address = f"{_xlsx_escape_sheet_name(sheet_name)}!{cell_ref}"
+        try:
+            value = evaluator.evaluate(address)
+        except Exception:
+            continue
+        if hasattr(value, "value"):
+            value = value.value
+        formatted = _format_formula_value(value)
+        if formatted is None:
+            continue
+        computed[(sheet_file, cell_ref)] = formatted
+
+    if not computed:
+        return
+
+    tmpdir = tempfile.mkdtemp()
+    try:
+        with zipfile.ZipFile(xlsx_path, 'r') as zin:
+            zin.extractall(tmpdir)
+        ns = {"s": S_NS}
+        updated: Dict[str, ET.ElementTree] = {}
+        for info in formula_cells:
+            sheet_file = info.get("sheet_file")
+            cell_ref = info.get("cell_ref")
+            if not sheet_file or not cell_ref:
+                continue
+            key = (sheet_file, cell_ref)
+            if key not in computed:
+                continue
+            sheet_path = os.path.join(tmpdir, "xl", "worksheets", sheet_file)
+            if not os.path.exists(sheet_path):
+                continue
+            if sheet_file not in updated:
+                updated[sheet_file] = ET.parse(sheet_path)
+            tree = updated[sheet_file]
+            root = tree.getroot()
+            cell = root.find(f".//s:c[@r='{cell_ref}']", ns)
+            if cell is None:
+                continue
+            v_node = cell.find("s:v", ns)
+            if v_node is None:
+                v_node = ET.SubElement(cell, f"{{{ns['s']}}}v")
+            v_node.text = computed[key]
+            if computed[key] in ("1", "0") and info.get("boolean", False):
+                cell.set("t", "b")
+            elif cell.get("t") == "str":
+                cell.attrib.pop("t")
+        for sheet_file, tree in updated.items():
+            sheet_path = os.path.join(tmpdir, "xl", "worksheets", sheet_file)
+            tree.write(sheet_path, encoding="utf-8", xml_declaration=True)
+        with zipfile.ZipFile(xlsx_path, 'w', zipfile.ZIP_DEFLATED) as zout:
+            for root_dir, _, files in os.walk(tmpdir):
+                for fn in files:
+                    full = os.path.join(root_dir, fn)
+                    zout.write(full, os.path.relpath(full, tmpdir))
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
 
 def xlsx_patch_and_place(src_xlsx: str, dst_xlsx: str, text_map: Dict[str, str], image_map: Dict[str, Dict]):
     """
@@ -216,9 +511,10 @@ def xlsx_patch_and_place(src_xlsx: str, dst_xlsx: str, text_map: Dict[str, str],
     2) fullCalcOnLoad=1 で再計算
     3) openpyxl で placements に新規画像挿入（既存図形/グラフは原則維持）
     """
-    ns = {"s":"http://schemas.openxmlformats.org/spreadsheetml/2006/main"}
+    ns = {"s": S_NS}
     tmpdir = tempfile.mkdtemp()
-    placements: List[Tuple[str, str, str]] = []  # (sheet_file, cell_ref, var)
+    placements: List[Dict[str, object]] = []
+    formula_cells: List[Dict[str, object]] = []
     try:
         with zipfile.ZipFile(src_xlsx, 'r') as zin:
             zin.extractall(tmpdir)
@@ -226,7 +522,7 @@ def xlsx_patch_and_place(src_xlsx: str, dst_xlsx: str, text_map: Dict[str, str],
         # sharedStrings
         sst_path = os.path.join(tmpdir, "xl", "sharedStrings.xml")
         numeric_candidates: Dict[int, Tuple[bool, Optional[float]]] = {}
-        img_sst_idx: Dict[int, str] = {}
+        img_sst_idx: Dict[int, Tuple[str, Optional[float]]] = {}
 
         if os.path.exists(sst_path):
             tree = ET.parse(sst_path); root = tree.getroot(); idx = -1
@@ -239,9 +535,9 @@ def xlsx_patch_and_place(src_xlsx: str, dst_xlsx: str, text_map: Dict[str, str],
                     original = "".join([(r.find("s:t", ns).text or "") for r in si.findall("s:r", ns) if r.find("s:t", ns) is not None])
 
                 # 画像タグ？
-                m_img = re.fullmatch(rf"\{{\[\s*({VAR_NAME})\s*\]\}}", original or "")
-                if m_img:
-                    img_sst_idx[idx] = m_img.group(1)
+                var, size_hint = parse_image_tag(original or "")
+                if var:
+                    img_sst_idx[idx] = (var, size_hint)
                     for r in list(si): si.remove(r)
                     t = ET.SubElement(si, f"{{{ns['s']}}}t"); t.text = ""
                     continue
@@ -265,16 +561,39 @@ def xlsx_patch_and_place(src_xlsx: str, dst_xlsx: str, text_map: Dict[str, str],
 
         # worksheets
         ws_dir = os.path.join(tmpdir, "xl", "worksheets")
+        sheet_map = _xlsx_sheet_map(tmpdir)
         if os.path.isdir(ws_dir):
             for fn in os.listdir(ws_dir):
                 if not fn.endswith(".xml"): continue
                 p = os.path.join(ws_dir, fn)
                 tree = ET.parse(p); root = tree.getroot()
 
+                sheet_name, sheet_index = sheet_map.get(fn, (None, None))
+                if sheet_index is None:
+                    m = re.findall(r'\d+', fn)
+                    sheet_index = int(m[0]) - 1 if m else 0
+
                 for c in root.findall(".//s:c", ns):
                     t_attr = c.get("t")
                     v_node = c.find("s:v", ns)
                     is_node = c.find("s:is", ns)
+                    f_node = c.find("s:f", ns)
+                    r_attr = c.get("r") or ""
+
+                    if f_node is not None:
+                        formula_cells.append({
+                            "sheet_file": fn,
+                            "sheet_name": sheet_name,
+                            "sheet_index": sheet_index,
+                            "cell_ref": r_attr,
+                            "boolean": (c.get("t") == "b"),
+                        })
+
+                    # 数式セルはキャッシュ値を削除し LibreOffice での再計算を確実化
+                    if f_node is not None and v_node is not None:
+                        try: c.remove(v_node)
+                        except: pass
+                        v_node = None
 
                     # shared string
                     if t_attr == "s" and v_node is not None and v_node.text:
@@ -282,8 +601,15 @@ def xlsx_patch_and_place(src_xlsx: str, dst_xlsx: str, text_map: Dict[str, str],
                         except: sst_idx = None
                         if sst_idx is not None and sst_idx in img_sst_idx:
                             # 画像座標として記録してセルは空に
-                            r_attr = c.get("r") or ""
-                            placements.append((fn, r_attr, img_sst_idx[sst_idx]))
+                            var, size_hint = img_sst_idx[sst_idx]
+                            placements.append({
+                                "sheet_file": fn,
+                                "sheet_name": sheet_name,
+                                "sheet_index": sheet_index,
+                                "cell_ref": r_attr,
+                                "var": var,
+                                "size_hint": size_hint,
+                            })
                             c.attrib.pop("t", None)
                             c.remove(v_node)
                             continue
@@ -298,10 +624,16 @@ def xlsx_patch_and_place(src_xlsx: str, dst_xlsx: str, text_map: Dict[str, str],
                         t_inline = is_node.find("s:t", ns)
                         if t_inline is not None and t_inline.text is not None:
                             txt = t_inline.text
-                            m_img = re.fullmatch(rf"\{{\[\s*({VAR_NAME})\s*\]\}}", txt or "")
-                            if m_img:
-                                r_attr = c.get("r") or ""
-                                placements.append((fn, r_attr, m_img.group(1)))
+                            var, size_hint = parse_image_tag(txt or "")
+                            if var:
+                                placements.append({
+                                    "sheet_file": fn,
+                                    "sheet_name": sheet_name,
+                                    "sheet_index": sheet_index,
+                                    "cell_ref": r_attr,
+                                    "var": var,
+                                    "size_hint": size_hint,
+                                })
                                 c.attrib.pop("t", None)
                                 try: c.remove(is_node)
                                 except: pass
@@ -346,10 +678,17 @@ def xlsx_patch_and_place(src_xlsx: str, dst_xlsx: str, text_map: Dict[str, str],
         import requests
 
         wb = load_workbook(dst_xlsx)
-        for sheet_file, cell_ref, var in placements:
+        for item in placements:
+            sheet_file = item.get("sheet_file")
+            cell_ref = item.get("cell_ref")
+            var = item.get("var")
+            size_hint = item.get("size_hint")
+            sheet_index = item.get("sheet_index") or 0
+            sheet_name = item.get("sheet_name")
             meta = image_map.get(var)
             if not meta: continue
-            url = meta["url"]; mm = meta.get("mm")
+            url = meta["url"]
+            mm = meta.get("mm") or size_hint
             r = requests.get(url, timeout=20); r.raise_for_status()
             img = PILImage.open(io.BytesIO(r.content)).convert("RGBA")
             if mm:
@@ -358,11 +697,17 @@ def xlsx_patch_and_place(src_xlsx: str, dst_xlsx: str, text_map: Dict[str, str],
                 new_h = int(round(h * (px / w))) if w else h
                 img = img.resize((px, new_h), PILImage.LANCZOS)
             bio = io.BytesIO(); img.save(bio, format="PNG"); bio.seek(0)
-            # sheet_file は "sheetX.xml"。概ねワークブックの順序に対応
-            sheet_index = int(re.findall(r'\d+', sheet_file)[0]) - 1
-            ws = wb.worksheets[sheet_index] if 0 <= sheet_index < len(wb.worksheets) else wb.active
+            ws = None
+            if sheet_name and sheet_name in wb:
+                ws = wb[sheet_name]
+            elif isinstance(sheet_index, int) and 0 <= sheet_index < len(wb.worksheets):
+                ws = wb.worksheets[sheet_index]
+            if ws is None:
+                ws = wb.active
             ws.add_image(XLImage(bio), cell_ref)
         wb.save(dst_xlsx)
+
+    xlsx_update_formula_caches(dst_xlsx, formula_cells)
 
 # ------------ PDF / JPEG ------------
 def libreoffice_to_pdf(input_path: str, out_dir: str) -> str:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pypdf==4.3.1
 python-multipart==0.0.9
 jinja2==3.1.4
 lxml==5.3.0
+xlcalculator==0.5.0


### PR DESCRIPTION
## Summary
- keep undefined DOCX placeholders intact for post-processing by rendering with a DebugUndefined Jinja environment
- add XML-aware text replacement that rewrites run content and inserts Word line breaks so DOCX shapes and split runs receive mapping values reliably

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68d3593bd270833283f67f36df314185