### PR TITLE
Fix Excel namespace handling for image insertion

### DIFF
--- a/main.py
+++ b/main.py
@@ -1232,10 +1232,8 @@ def xlsx_patch_and_place(src_xlsx: str, dst_xlsx: str, text_map: Dict[str, str],
                     root.set("xmlns:r", R_NS)
                     tree = ET.ElementTree(root)
                 root = tree.getroot()
-                if root.get(f"{{{XMLNS_NS}}}r") is None and not any(
-                    attr.endswith("}r") for attr in root.attrib
-                ):
-                    root.set(f"{{{XMLNS_NS}}}r", R_NS)
+                if not any(attr == "xmlns:r" or attr.endswith("}r") for attr in root.attrib):
+                    root.set("xmlns:r", R_NS)
                 drawing_rels_path = os.path.join(drawings_rels_dir, f"{drawing_name}.rels")
                 if os.path.exists(drawing_rels_path):
                     rels_tree = ET.parse(drawing_rels_path)
@@ -1418,10 +1416,8 @@ def xlsx_patch_and_place(src_xlsx: str, dst_xlsx: str, text_map: Dict[str, str],
                     if sheet_tree is None:
                         continue
                     sheet_root = sheet_tree.getroot()
-                    if sheet_root.get(f"{{{XMLNS_NS}}}r") is None and not any(
-                        attr.endswith("}r") for attr in sheet_root.attrib
-                    ):
-                        sheet_root.set(f"{{{XMLNS_NS}}}r", R_NS)
+                    if not any(attr == "xmlns:r" or attr.endswith("}r") for attr in sheet_root.attrib):
+                        sheet_root.set("xmlns:r", R_NS)
 
                     sheet_rels_tree = _ensure_sheet_rels(sheet_file)
                     rels_root = sheet_rels_tree.getroot()


### PR DESCRIPTION
## Summary
- ensure worksheet and drawing XML roots declare the relationships namespace using a valid attribute
- prevent generation of invalid xmlns namespace bindings when placing Excel images

## Testing
- python - <<'PY'
import main
image_map={'logo':{'url':'http://127.0.0.1:8000/red.png','mm':None}}
text_map={}
main.xlsx_patch_and_place('sample.xlsx','out_fixed.xlsx',text_map,image_map)
PY
- python - <<'PY'
from openpyxl import load_workbook
wb=load_workbook('out_fixed.xlsx')
print('sheets', wb.sheetnames)
print('A1', wb.active['A1'].value)
PY

------
https://chatgpt.com/codex/tasks/task_e_68d61fce2c208332b67c4d967de9532b