### PR TITLE
Stabilize Excel drawing namespace prefixes

### DIFF
--- a/main.py
+++ b/main.py
@@ -235,6 +235,12 @@ CONTENT_TYPES_NS = "http://schemas.openxmlformats.org/package/2006/content-types
 EMU_PER_INCH = 914400
 XDR_NS = "http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing"
 EMU_PER_PIXEL = 9525
+
+# Ensure common OpenXML namespaces retain stable prefixes when serializing.
+ET.register_namespace("r", R_NS)
+ET.register_namespace("xdr", XDR_NS)
+ET.register_namespace("a", A_NS)
+ET.register_namespace("s", S_NS)
 CELL_REF_RE = re.compile(r"^([A-Za-z]+)(\d+)$")
 
 def _word_set_text(node: LET._Element, text: str):
@@ -1227,15 +1233,8 @@ def xlsx_patch_and_place(src_xlsx: str, dst_xlsx: str, text_map: Dict[str, str],
                     tree = ET.parse(drawing_path)
                 else:
                     root = ET.Element(f"{{{XDR_NS}}}wsDr")
-                    root.set("xmlns:xdr", XDR_NS)
-                    root.set("xmlns:a", A_NS)
-                    root.set("xmlns:r", R_NS)
                     tree = ET.ElementTree(root)
                 root = tree.getroot()
-                if root.get(f"{{{XMLNS_NS}}}r") is None and not any(
-                    attr.endswith("}r") for attr in root.attrib
-                ):
-                    root.set(f"{{{XMLNS_NS}}}r", R_NS)
                 drawing_rels_path = os.path.join(drawings_rels_dir, f"{drawing_name}.rels")
                 if os.path.exists(drawing_rels_path):
                     rels_tree = ET.parse(drawing_rels_path)
@@ -1418,10 +1417,6 @@ def xlsx_patch_and_place(src_xlsx: str, dst_xlsx: str, text_map: Dict[str, str],
                     if sheet_tree is None:
                         continue
                     sheet_root = sheet_tree.getroot()
-                    if sheet_root.get(f"{{{XMLNS_NS}}}r") is None and not any(
-                        attr.endswith("}r") for attr in sheet_root.attrib
-                    ):
-                        sheet_root.set(f"{{{XMLNS_NS}}}r", R_NS)
 
                     sheet_rels_tree = _ensure_sheet_rels(sheet_file)
                     rels_root = sheet_rels_tree.getroot()


### PR DESCRIPTION
## Summary
- register standard OpenXML namespaces so ElementTree preserves the expected r/xdr/a prefixes when rewriting Excel parts
- rely on the registered namespaces when emitting drawing and worksheet XML, preventing corrupted drawing relationships when image tags are replaced

## Testing
- python - <<'PY'
import importlib, io, zipfile
from openpyxl import Workbook, load_workbook
import main
importlib.reload(main)
wb=Workbook()
ws=wb.active
ws['A1'] = '{[logo]}'
wb.save('sample.xlsx')
image_map={'logo':{'url':'http://127.0.0.1:8000/red.png','mm':None}}
text_map={}
import requests
from PIL import Image
img = Image.new('RGB',(10,5),(255,0,0))
buf = io.BytesIO()
img.save(buf, format='PNG')
data = buf.getvalue()
class DummyResp:
    def __init__(self, content):
        self.content = content
        self.status_code = 200
    def raise_for_status(self):
        pass
orig_get = requests.get
try:
    requests.get = lambda url, timeout=20: DummyResp(data)
    main.xlsx_patch_and_place('sample.xlsx','out.xlsx',text_map,image_map)
finally:
    requests.get = orig_get
wb2 = load_workbook('out.xlsx')
print('A1 value after placement:', wb2.active['A1'].value)
with zipfile.ZipFile('out.xlsx','r') as zf:
    xml = zf.read('xl/worksheets/sheet1.xml').decode('utf-8')
print('contains r:id attribute:', 'r:id="rId1"' in xml)
PY

------
https://chatgpt.com/codex/tasks/task_e_68d61fce2c208332b67c4d967de9532b