### PR TITLE
Handle XML default namespace fallback

### DIFF
--- a/main.py
+++ b/main.py
@@ -276,7 +276,13 @@ def _xml_write_tree(tree: ET.ElementTree, path: str, default_namespace: Optional
                 kwargs["default_namespace"] = default_namespace
             else:
                 kwargs["default_namespace"] = default_namespace
-    tree.write(path, **kwargs)
+    try:
+        tree.write(path, **kwargs)
+    except ValueError as exc:
+        if "non-qualified names" in str(exc) and kwargs.pop("default_namespace", None):
+            tree.write(path, **kwargs)
+        else:
+            raise
 
 def _word_set_text(node: LET._Element, text: str):
     run = node.getparent()


### PR DESCRIPTION
## Summary
- add a fallback when writing XML files so we retry without the default namespace if ElementTree raises a non-qualified names error
- prevents Excel uploads from failing with a 400 response during XML serialization

## Testing
- python -m py_compile main.py

------
https://chatgpt.com/codex/tasks/task_e_68d664d6af748332acb7188608a86b82