### PR TITLE
Restore compatibility for Excel loop templates

### DIFF
--- a/main.py
+++ b/main.py
@@ -101,6 +101,7 @@ VAR_NAME = r"[A-Za-z_][A-Za-z0-9_]*"
 VAR_PATH = r"[A-Za-z_][A-Za-z0-9_]*(?::[A-Za-z_][A-Za-z0-9_]*)*"
 IMG_KEY_PATTERN = re.compile(rf"^\{{\[(?P<var>{VAR_NAME})\](?::(?P<size>[^}}]+))?\}}$")
 TXT_KEY_PATTERN = re.compile(rf"^\{{(?P<var>{VAR_NAME})\}}$")
+TEXT_TOKEN_PATTERN = re.compile(rf"\{{\s*(?P<var>{VAR_NAME})\s*\}}")
 LOOP_KEY_PATTERN = re.compile(rf"^\{{(?P<group>{VAR_NAME}):loop:(?P<field>{VAR_NAME})\}}$")
 IMG_TAG_PATTERN = re.compile(rf"\{{\[(?P<var>{VAR_NAME})\](?::(?P<size>[^}}]+))?\}}")
 WORD_INLINE_PATTERN = re.compile(
@@ -234,10 +235,14 @@ def parse_mapping_text(raw: str) -> Tuple[Dict[str, str], Dict[str, Dict], Dict[
 def _apply_text_tokens(text: Optional[str], text_map: Dict[str, str]) -> Optional[str]:
     if text is None or not text_map:
         return text
-    result = text
-    for key, value in text_map.items():
-        result = result.replace(f"{{{key}}}", value)
-    return result
+
+    def _replace(match: re.Match[str]) -> str:
+        var = match.group("var")
+        if var in text_map:
+            return text_map[var]
+        return match.group(0)
+
+    return TEXT_TOKEN_PATTERN.sub(_replace, text)
 
 def mm_to_pixels(mm: float, dpi: int = 96) -> int:
     return int(round(mm / 25.4 * dpi))
@@ -1142,21 +1147,100 @@ def _xlsx_expand_loops(
     while idx < len(rows):
         row = rows[idx]
         group: Optional[str] = None
+        start_cell_text: Optional[str] = None
         for cell in row.findall("s:c", ns):
-            text = (_xlsx_cell_text(cell, ns, shared_strings) or "").strip()
+            raw_text = _xlsx_cell_text(cell, ns, shared_strings) or ""
+            text = raw_text.strip()
             if not text:
                 continue
             detected_group = _xlsx_find_loop_group_in_text(text)
             if detected_group:
+                if group and detected_group != group:
+                    raise ValueError(
+                        "Multiple loop groups in a single row are not supported"
+                    )
                 group = detected_group
-                break
+                start_cell_text = raw_text
         if not group:
             idx += 1
             continue
 
-        end_idx = idx
-        while end_idx < len(rows):
-            candidate_row = rows[end_idx]
+        start_pattern = re.compile(
+            rf"^\s*\{{\s*{re.escape(group)}\s*:\s*loop\s*\}}\s*$"
+        )
+        strict_applied = False
+        if start_cell_text and start_pattern.match(start_cell_text):
+            group_field_pattern = re.compile(
+                rf"\{{\s*{re.escape(group)}\s*:\s*{VAR_NAME}\s*\}}"
+            )
+            loop_field_pattern = re.compile(
+                rf"\{{\s*{re.escape(group)}\s*:\s*loop\s*:\s*{VAR_NAME}\s*\}}"
+            )
+            end_idx = idx + 1
+            end_row: Optional[ET.Element] = None
+            while end_idx < len(rows):
+                candidate_row = rows[end_idx]
+                found_end = False
+                for cell in candidate_row.findall("s:c", ns):
+                    raw_text = _xlsx_cell_text(cell, ns, shared_strings) or ""
+                    text = raw_text.strip()
+                    if not text:
+                        continue
+                    if text == "#end":
+                        if not re.fullmatch(r"\s*#end\s*", raw_text):
+                            break
+                        found_end = True
+                        break
+                if found_end:
+                    end_row = candidate_row
+                    break
+                end_idx += 1
+
+            if end_row is not None:
+                block_rows = rows[idx + 1 : end_idx]
+                template_bases = [copy.deepcopy(r) for r in block_rows]
+                if template_bases:
+                    for remove_row in [row] + block_rows + [end_row]:
+                        sheet_data.remove(remove_row)
+
+                    entries = loop_map.get(group, [])
+                    insert_pos = idx
+
+                    if entries:
+                        for entry_idx, entry in enumerate(entries):
+                            for tmpl in template_bases:
+                                clone = copy.deepcopy(tmpl)
+                                for cell in clone.findall("s:c", ns):
+                                    original_text = _xlsx_cell_text(
+                                        cell, ns, shared_strings
+                                    )
+                                    if original_text is None:
+                                        original_text = ""
+                                    has_group_token = bool(
+                                        loop_field_pattern.search(original_text)
+                                        or group_field_pattern.search(original_text)
+                                        or _xlsx_cell_has_loop_token(
+                                            original_text, group
+                                        )
+                                    )
+                                    replaced = _xlsx_apply_loop_text(
+                                        original_text, group, entry, text_map
+                                    )
+                                    if replaced != original_text or has_group_token:
+                                        _xlsx_set_inline_text(cell, ns, replaced)
+                                if clone.findall("s:c", ns):
+                                    sheet_data.insert(insert_pos, clone)
+                                    insert_pos += 1
+
+                    rows = list(sheet_data.findall("s:row", ns))
+                    idx = insert_pos
+                    strict_applied = True
+        if strict_applied:
+            continue
+
+        legacy_end_idx = idx
+        while legacy_end_idx < len(rows):
+            candidate_row = rows[legacy_end_idx]
             has_group_token = False
             for cell in candidate_row.findall("s:c", ns):
                 text = (_xlsx_cell_text(cell, ns, shared_strings) or "").strip()
@@ -1165,36 +1249,31 @@ def _xlsx_expand_loops(
                 if text == "#end" or _xlsx_cell_has_loop_token(text, group):
                     has_group_token = True
                     break
-            if not has_group_token and end_idx > idx:
-                break
             if not has_group_token:
-                # The anchor row must contain the loop token; if it does not
-                # we fall back to treating it as a single-row loop block.
-                if end_idx == idx:
+                if legacy_end_idx == idx:
                     has_group_token = True
                 else:
                     break
-            end_idx += 1
+            legacy_end_idx += 1
 
-        block_rows = rows[idx:end_idx]
+        block_rows = rows[idx:legacy_end_idx]
         if not block_rows:
             idx += 1
             continue
+
         template_bases = [copy.deepcopy(r) for r in block_rows]
         cleaned_templates: List[ET.Element] = []
         for base in template_bases:
-            # Remove explicit "#end" markers but keep loop placeholders so that
-            # the duplicated rows stay anchored at the original start cell.
             for cell in list(base.findall("s:c", ns)):
                 cell_text = (_xlsx_cell_text(cell, ns, shared_strings) or "").strip()
                 if not cell_text:
                     continue
                 if cell_text == "#end":
                     base.remove(cell)
-                    continue
             if base.findall("s:c", ns):
                 cleaned_templates.append(base)
         template_bases = cleaned_templates or template_bases
+
         for original in block_rows:
             sheet_data.remove(original)
 
@@ -1209,8 +1288,12 @@ def _xlsx_expand_loops(
                         original_text = _xlsx_cell_text(cell, ns, shared_strings)
                         if original_text is None:
                             continue
-                        has_group_token = _xlsx_cell_has_loop_token(original_text, group)
-                        replaced = _xlsx_apply_loop_text(original_text, group, entry, text_map)
+                        has_group_token = _xlsx_cell_has_loop_token(
+                            original_text, group
+                        )
+                        replaced = _xlsx_apply_loop_text(
+                            original_text, group, entry, text_map
+                        )
                         if entry_idx > 0 and not has_group_token:
                             cells_to_remove.append(cell)
                             continue
@@ -1225,6 +1308,7 @@ def _xlsx_expand_loops(
                     if clone.findall("s:c", ns):
                         sheet_data.insert(insert_pos, clone)
                         insert_pos += 1
+
         rows = list(sheet_data.findall("s:row", ns))
         idx = insert_pos if entries else idx
 


### PR DESCRIPTION
## Summary
- keep the structured loop duplication path for clean `{group:loop}` / `#end` blocks while only applying it when both markers are present
- fall back to the previous inline loop expansion strategy when templates combine loop markers or omit `#end`, preserving existing documents

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68d78e78f0a4833298dab63b63a84c46