### PR TITLE
Remove authentication requirement from merge endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ This project exposes a FastAPI application that patches Word (`.docx`) or Excel 
 * System tools used by the conversion pipeline:
   * `soffice` (LibreOffice) for Office → PDF conversion
   * `pdftoppm` for PDF → JPEG conversion
-* The services that call this API must pass a valid `auth_id`. The server validates this token against `AUTH_API_BASE_URL` (defaults to the production endpoint in `main.py`).
-  * If the upstream auth service is unavailable you can allow requests to proceed by leaving `AUTH_ALLOW_ON_UNAVAILABLE` at its default of `true`. Set it to `false` to preserve the strict 503 failure mode.
 
 Install Python dependencies:
 
@@ -39,7 +37,6 @@ The server exposes a health check at `GET /healthz` and the main processing endp
 | `return_pdf` | form-data | bool | When `true`, include the merged PDF data URI |
 | `return_jpegs` | form-data | bool | When `true`, include JPEG previews |
 | `return_document` | form-data | bool | When `true`, include the patched `.docx`/`.xlsx` data URI |
-| `X-Auth-Id` | header | string | Required authentication token |
 
 Provide the Office template either as a multipart file upload (`file`), a data URI/Base64 string (`file_data_uri`), or a downloadable URL (`file_url`). Only one source is required. Responses are JSON. Depending on the selected flags the payload can contain `pdf_data_uri`, `jpeg_data_uris`, and/or `document_data_uri` entries. All binary payloads are returned as data URIs with appropriate MIME types.
 
@@ -80,7 +77,6 @@ If the download fails or the data cannot be decoded the placeholder is left unto
 
 ```bash
 curl -X POST http://localhost:8080/merge \
-  -H 'X-Auth-Id: YOUR_AUTH_ID' \
   -F 'file=@template.xlsx' \
   -F 'mapping_text={name}:Alice,{[logo]}:data:image/png;base64,iVBORw0...' \
   -F 'filename=report' \
@@ -99,4 +95,4 @@ python -m compileall main.py
 
 ## Deployment
 
-The application is packaged for Google Cloud Run via the provided `Dockerfile`. Ensure the runtime image has LibreOffice and Poppler (`pdftoppm`) installed and set the `AUTH_API_BASE_URL` environment variable if you need to target a non-default authentication service.
+The application is packaged for Google Cloud Run via the provided `Dockerfile`. Ensure the runtime image has LibreOffice and Poppler (`pdftoppm`) installed.

--- a/main.py
+++ b/main.py
@@ -8,32 +8,21 @@ import zipfile
 import shutil
 import subprocess
 import threading
-import time
 import xml.etree.ElementTree as ET
 from decimal import Decimal
 from lxml import etree as LET
 from jinja2 import Environment, DebugUndefined
-from typing import Dict, Tuple, List, Optional, Set
+from typing import Any, Dict, Tuple, List, Optional, Set, Mapping
 import urllib.parse
 
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-from fastapi import FastAPI, UploadFile, File, Form, Header
+from fastapi import FastAPI, UploadFile, File, Form
 from fastapi.responses import JSONResponse
 
-DEFAULT_AUTH_API_BASE_URL = "https://auth-677366504119.asia-northeast1.run.app"
-
-_AUTH_SESSION_LOCAL = threading.local()
-_AUTH_CACHE_LOCK = threading.Lock()
-_AUTH_CACHE: Dict[str, Tuple[float, bool]] = {}
 _GENERIC_HTTP_SESSION_LOCAL = threading.local()
-
-
-class AuthServiceUnavailable(RuntimeError):
-    """Raised when the external auth validation service is unavailable."""
-
 
 def _build_retry(
     total: int,
@@ -58,21 +47,6 @@ def _configure_session(session: requests.Session, retry: Retry) -> requests.Sess
     adapter = HTTPAdapter(pool_connections=8, pool_maxsize=8, max_retries=retry)
     session.mount("https://", adapter)
     session.mount("http://", adapter)
-    return session
-
-
-def _get_auth_session() -> requests.Session:
-    session = getattr(_AUTH_SESSION_LOCAL, "session", None)
-    if session is None:
-        retry = _build_retry(
-            total=int(os.environ.get("AUTH_API_RETRIES", "3")),
-            connect=int(os.environ.get("AUTH_API_RETRIES_CONNECT", "3")),
-            read=int(os.environ.get("AUTH_API_RETRIES_READ", "3")),
-            status=int(os.environ.get("AUTH_API_RETRIES_STATUS", "3")),
-            backoff_factor=float(os.environ.get("AUTH_API_RETRY_BACKOFF", "0.5")),
-        )
-        session = _configure_session(requests.Session(), retry)
-        _AUTH_SESSION_LOCAL.session = session
     return session
 
 
@@ -112,18 +86,13 @@ def run(cmd: List[str], cwd: Optional[str] = None):
     return proc
 
 def ok(d): return JSONResponse(status_code=200, content=d)
-def err(m, status=400): return JSONResponse(status_code=status, content={"error": str(m)})
-
-
-def _auth_api_timeout() -> float:
-    try:
-        return float(os.environ.get("AUTH_API_TIMEOUT", "5"))
-    except ValueError:
-        return 5.0
-
-
-def _auth_soft_fail_enabled() -> bool:
-    return (os.environ.get("AUTH_ALLOW_ON_UNAVAILABLE", "true").lower() in {"1", "true", "yes", "on"})
+def err(message, status=400):
+    if isinstance(message, Mapping):
+        payload = dict(message)
+        if "error" not in payload:
+            payload["error"] = str(payload.get("message", "")) or "Unknown error"
+        return JSONResponse(status_code=status, content=payload)
+    return JSONResponse(status_code=status, content={"error": str(message)})
 
 
 def _generic_http_timeout() -> float:
@@ -132,64 +101,6 @@ def _generic_http_timeout() -> float:
     except ValueError:
         return 20.0
 
-
-def validate_auth_id(auth_id: str) -> bool:
-    base_url = (os.environ.get("AUTH_API_BASE_URL") or DEFAULT_AUTH_API_BASE_URL or "").rstrip("/")
-    if not base_url:
-        raise RuntimeError("AUTH_API_BASE_URL is not configured")
-    if not auth_id:
-        return False
-
-    try:
-        cache_ttl = max(float(os.environ.get("AUTH_API_CACHE_TTL", "30")), 0.0)
-    except ValueError:
-        cache_ttl = 30.0
-    if cache_ttl:
-        now = time.monotonic()
-        with _AUTH_CACHE_LOCK:
-            cached = _AUTH_CACHE.get(auth_id)
-            if cached and cached[0] >= now:
-                return cached[1]
-
-    url = f"{base_url}/auth-ids/verify"
-    payload = {"auth_id": auth_id}
-    session = _get_auth_session()
-    try:
-        resp = session.post(url, json=payload, timeout=_auth_api_timeout())
-    except requests.RequestException as exc:
-        raise AuthServiceUnavailable(f"auth_id validation request failed: {exc}")
-
-    if resp.status_code in {401, 404}:
-        return False
-    if resp.status_code >= 400:
-        if resp.status_code >= 500:
-            raise AuthServiceUnavailable(
-                f"auth_id validation service unavailable (status {resp.status_code})"
-            )
-        raise RuntimeError(f"auth_id validation failed with status {resp.status_code}")
-
-    try:
-        data = resp.json()
-    except ValueError as exc:
-        raise RuntimeError("auth_id validation returned invalid JSON") from exc
-
-    result = bool(data.get("is_valid"))
-    if cache_ttl:
-        expires_at = time.monotonic() + cache_ttl
-        with _AUTH_CACHE_LOCK:
-            _AUTH_CACHE[auth_id] = (expires_at, result)
-            if len(_AUTH_CACHE) > 1024:
-                cutoff = time.monotonic()
-                stale = [k for k, (expiry, _) in _AUTH_CACHE.items() if expiry < cutoff]
-                for key in stale:
-                    _AUTH_CACHE.pop(key, None)
-                if len(_AUTH_CACHE) > 1024:
-                    try:
-                        oldest_key = next(iter(_AUTH_CACHE))
-                        _AUTH_CACHE.pop(oldest_key, None)
-                    except StopIteration:
-                        pass
-    return result
 
 # ------------ tag & number parsing ------------
 VAR_NAME = r"[A-Za-z_][A-Za-z0-9_]*"
@@ -2370,31 +2281,10 @@ async def merge(
     return_document: bool = Form(True),
     file_data_uri: str = Form(""),
     file_url: str = Form(""),
-    x_auth_id: Optional[str] = Header(None, alias="X-Auth-Id"),
-    authorization: Optional[str] = Header(None),
 ):
     from pypdf import PdfReader  # lazy import
 
     try:
-        auth_id = x_auth_id or ""
-        if not auth_id and authorization:
-            auth_id = authorization.strip()
-            if auth_id.lower().startswith("bearer "):
-                auth_id = auth_id[7:].strip()
-
-        if not auth_id:
-            return err("missing auth_id", status=401)
-
-        auth_warning: Optional[str] = None
-        try:
-            if not validate_auth_id(auth_id):
-                return err("invalid auth_id", status=401)
-        except AuthServiceUnavailable as exc:
-            if _auth_soft_fail_enabled():
-                auth_warning = str(exc)
-            else:
-                return err(str(exc), status=503)
-
         template_bytes: Optional[bytes] = None
         ext = ""
         if file is not None:
@@ -2488,9 +2378,6 @@ async def merge(
 
             if not response:
                 response["message"] = "No outputs requested"
-
-            if auth_warning:
-                response.setdefault("warnings", []).append(auth_warning)
 
             return ok(response)
     except Exception as e:


### PR DESCRIPTION
## Summary
- remove the legacy authentication validation logic and related environment variables
- simplify the /merge endpoint to no longer expect auth headers
- update the documentation to reflect the unauthenticated API usage

## Testing
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68d7e80dece0833286cfe9d6523a2d8c